### PR TITLE
Allow passing of 'startAudioOff' to DailyCallObject

### DIFF
--- a/vapi.ts
+++ b/vapi.ts
@@ -161,7 +161,7 @@ export default class Vapi extends VapiEventEmitter {
       DailyAdvancedConfig,
       'avoidEval' | 'alwaysIncludeMicInPermissionPrompt'
     >,
-    dailyCallObject?: Pick<DailyFactoryOptions, 'audioSource'>,
+    dailyCallObject?: Pick<DailyFactoryOptions, 'audioSource' | 'startAudioOff'>,
   ) {
     super();
     client.baseUrl = apiBaseUrl ?? 'https://api.vapi.ai';


### PR DESCRIPTION
Currently its not possible to begin a Vapi web call with the user's microphone muted. This changeallows the 'startAudioOff' parameter to be passed through to the Daily call, making it possible to start the call muted. This is valuable for allowing push-to-talk for Vapi web call.s