### PR TITLE
Add custom parameters to Vapi.start to pass it to backend

### DIFF
--- a/vapi.ts
+++ b/vapi.ts
@@ -289,6 +289,7 @@ export default class Vapi extends VapiEventEmitter {
     workflow?: CreateWorkflowDTO | string,
     workflowOverrides?: WorkflowOverrides,
     options?: StartCallOptions
+    customParams?: Record<string, any>
   ): Promise<Call | null> {
     const startTime = Date.now();
     
@@ -348,7 +349,8 @@ export default class Vapi extends VapiEventEmitter {
           workflowId: typeof workflow === 'string' ? workflow : undefined,
           workflowOverrides,
           roomDeleteOnUserLeaveEnabled: options?.roomDeleteOnUserLeaveEnabled,
-        })
+        }),
+        customParams
       ).data;
       
       const webCallDuration = Date.now() - webCallStartTime;


### PR DESCRIPTION
for example {headers: {'test':'information'}} to add custom header 