### PR TITLE
Use meeting token to start video recording automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ vapi.on('error', (e) => {
 
 ## Recording
 
-When video recording is enabled on the call's artifact plan, Vapi starts a recording automatically when the call begins. Recording start is asynchronous: success is signaled by the `recording-started` event and failure by the `recording-error` event.
+When video recording is enabled on the call's artifact plan, Vapi starts a recording automatically when the call begins. When the server provides a meeting token for the call (`call.transport.callToken`), the SDK joins with it and Daily auto-starts the cloud recording, which is more reliable on weak networks. Otherwise the SDK starts the recording from the client after joining. Recording start is asynchronous: success is signaled by the `recording-started` event and failure by the `recording-error` event.
 
 A failed recording start is not retried automatically. Use `startRecording()` and `stopRecording()` to control the recording yourself. For example, to retry after a failure:
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Vapi from '@vapi-ai/web';
 
 const VAPI_PUBLIC_KEY = import.meta.env.VITE_VAPI_PUBLIC_KEY;
@@ -30,6 +30,9 @@ function App() {
   const [networkTestRunning, setNetworkTestRunning] = useState(false);
   const [networkTestResults, setNetworkTestResults] = useState<any>(null);
   const [simulateFailure, setSimulateFailure] = useState<string>('none');
+  const [videoRecordingEnabled, setVideoRecordingEnabled] = useState(false);
+  const [localVideoTrack, setLocalVideoTrack] = useState<MediaStreamTrack | null>(null);
+  const localVideoRef = useRef<HTMLVideoElement | null>(null);
 
   useEffect(() => {
     // Check for stored webCall on component mount
@@ -61,7 +64,17 @@ function App() {
       setConnected(false);
       setAssistantIsSpeaking(false);
       setVolumeLevel(0);
-      addMessage('system', 'Call ended - webCall data preserved for reconnection');
+      setLocalVideoTrack(null);
+      addMessage('system', 'Call ended');
+    });
+
+    // Tracks the local camera so the UI can show what's being recorded when
+    // video recording is enabled on the call.
+    vapi.on('daily-participant-updated', (participant) => {
+      if (!participant.local) return;
+      const video = participant.tracks?.video;
+      const track = video?.persistentTrack ?? video?.track ?? null;
+      setLocalVideoTrack(video?.state === 'playable' ? track : null);
     });
 
     vapi.on('speech-start', () => {
@@ -147,6 +160,15 @@ function App() {
     };
   }, [vapi]);
 
+  // Attach the local camera track to the preview element whenever it changes.
+  useEffect(() => {
+    if (localVideoRef.current) {
+      localVideoRef.current.srcObject = localVideoTrack
+        ? new MediaStream([localVideoTrack])
+        : null;
+    }
+  }, [localVideoTrack]);
+
   const addMessage = (type: 'user' | 'assistant' | 'system', content: string) => {
     setMessages(prev => [...prev, {
       time: new Date().toLocaleTimeString(),
@@ -203,6 +225,9 @@ function App() {
         firstMessage: "Hello! I'm your AI assistant. How can I help you today?",
         endCallMessage: "Thank you for the conversation. Goodbye!",
         endCallPhrases: ["goodbye", "bye", "end call", "hang up"],
+        artifactPlan: {
+          videoRecordingEnabled,
+        },
         
         // Max call duration (in seconds) - 10 minutes
         maxDurationSeconds: 600
@@ -216,7 +241,8 @@ function App() {
           webCallUrl: (webCall as any).webCallUrl,
           id: webCall.id,
           artifactPlan: webCall.artifactPlan,
-          assistant: webCall.assistant
+          assistant: webCall.assistant,
+          transport: webCall.transport,
         };
         localStorage.setItem('vapi-webcall', JSON.stringify(webCallToStore));
         setStoredWebCall(webCallToStore);
@@ -230,7 +256,19 @@ function App() {
   };
 
   const stopCall = () => {
+    // Leaves the call without ending it server-side. With
+    // roomDeleteOnUserLeaveEnabled: false the call stays alive, so you can
+    // rejoin it with the Reconnect button.
+    vapi.stop();
+    addMessage('system', 'Left the call - it stays alive for reconnection');
+  };
+
+  const endCall = () => {
+    // Ends the Vapi call for everyone; reconnection is not possible after this.
     vapi.end();
+    localStorage.removeItem('vapi-webcall');
+    setStoredWebCall(null);
+    addMessage('system', 'Ended the call - stored call data cleared');
   };
 
   const reconnectCall = async () => {
@@ -445,6 +483,56 @@ function App() {
         )}
       </div>
 
+      {/* Local Camera Preview */}
+      {localVideoTrack && (
+        <div style={{
+          backgroundColor: '#111827',
+          borderRadius: '8px',
+          padding: '15px',
+          marginBottom: '20px'
+        }}>
+          <video
+            ref={localVideoRef}
+            autoPlay
+            playsInline
+            muted
+            style={{
+              width: '100%',
+              maxWidth: '400px',
+              display: 'block',
+              margin: '0 auto',
+              borderRadius: '6px',
+              transform: 'scaleX(-1)'
+            }}
+          />
+        </div>
+      )}
+
+      {/* Call Settings */}
+      <div style={{
+        backgroundColor: '#eff6ff',
+        border: '1px solid #bfdbfe',
+        borderRadius: '8px',
+        padding: '15px',
+        marginBottom: '20px'
+      }}>
+        <h4 style={{ marginTop: 0, marginBottom: '10px', color: '#1d4ed8' }}>⚙️ Call Settings</h4>
+        <label style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <input
+            type="checkbox"
+            checked={videoRecordingEnabled}
+            onChange={(e) => setVideoRecordingEnabled(e.target.checked)}
+            disabled={connected}
+            style={{ cursor: connected ? 'not-allowed' : 'pointer' }}
+          />
+          <span style={{ fontWeight: '500' }}>🎥 Video Recording Enabled</span>
+        </label>
+        <p style={{ fontSize: '12px', color: '#6b7280', marginBottom: 0, marginTop: '10px' }}>
+          When enabled, your camera turns on and the call is recorded to video. Applies to the next
+          call you start.
+        </p>
+      </div>
+
       {/* Failure Simulation Controls */}
       <div style={{
         backgroundColor: '#fef2f2',
@@ -532,8 +620,24 @@ function App() {
           </button>
         )}
         
-        <button 
-          onClick={stopCall} 
+        <button
+          onClick={stopCall}
+          disabled={!connected}
+          style={{
+            padding: '12px 24px',
+            backgroundColor: !connected ? '#9ca3af' : '#f97316',
+            color: 'white',
+            border: 'none',
+            borderRadius: '6px',
+            cursor: !connected ? 'not-allowed' : 'pointer',
+            fontSize: '16px'
+          }}
+        >
+          Stop Call (leave)
+        </button>
+
+        <button
+          onClick={endCall}
           disabled={!connected}
           style={{
             padding: '12px 24px',
@@ -545,9 +649,9 @@ function App() {
             fontSize: '16px'
           }}
         >
-          Stop Call
+          End Call
         </button>
-        
+
         <button 
           onClick={toggleMute} 
           disabled={!connected}
@@ -936,7 +1040,7 @@ function App() {
           <li>Speak naturally - the AI will respond with voice</li>
           <li>Use "Mute" to temporarily disable your microphone</li>
           <li>Say "goodbye" or "end call" to end the conversation</li>
-          <li>Click "Stop Call" to manually end the call</li>
+          <li>Click "End Call" to end the call, or click "Stop Call" to leave without ending (you can reconnect later)</li>
           <li><strong>Network Testing:</strong> Use "Test Network" before starting a call to check connectivity to TURN servers and WebSocket support</li>
           <li><strong>Persistent Storage:</strong> Call data is automatically saved and persists even after calls end</li>
           <li><strong>Reconnection:</strong> Use "Reconnect to Stored Call" to rejoin your previous session anytime</li>

--- a/vapi.ts
+++ b/vapi.ts
@@ -236,10 +236,18 @@ type WebCall = {
   artifactPlan?: { videoRecordingEnabled?: boolean };
   /**
    * The Vapi WebCall assistant. This is the assistant of the call.
-   * 
+   *
    * call.assistant
    */
   assistant?: { voice?: { provider?: string } };
+  /**
+   * The Vapi WebCall transport. When video recording is enabled, the server
+   * sets `callToken` to a Daily meeting token that auto-starts the cloud
+   * recording on join.
+   *
+   * call.transport
+   */
+  transport?: { callToken?: string };
 }
 
 async function startAudioPlayer(
@@ -512,6 +520,14 @@ export default class Vapi extends VapiEventEmitter {
 
       const isVideoEnabled = webCall?.assistant?.voice?.provider === 'tavus';
 
+      // When video recording is enabled, the server sends a Daily meeting
+      // token that auto-starts the cloud recording on join — more reliable
+      // than calling startRecording() from a weak client network. Older
+      // servers don't send one; then the client starts the recording itself.
+      const callToken = (
+        webCall?.transport as { callToken?: string } | undefined
+      )?.callToken;
+
       // Stage 2: Create Daily call object
       this.emit('call-start-progress', {
         stage: 'daily-call-object-creation',
@@ -573,6 +589,8 @@ export default class Vapi extends VapiEventEmitter {
           this.hasEmittedCallEndedStatus = true;
         }
         if (isVideoRecordingEnabled) {
+          // When using a token, the recording doesn't stop automatically on
+          // leave, so still stop it manually to preserve existing behavior.
           this.call?.stopRecording();
         }
         this.cleanup().catch(console.error);
@@ -651,6 +669,28 @@ export default class Vapi extends VapiEventEmitter {
         this.detachAudioPlayer(e.participant.session_id);
       });
 
+      // Registered before join(): a token-auto-started recording can begin
+      // while join() is still in flight, so a listener added after join
+      // could miss the event.
+      let recordingRequestedTime = 0;
+      if (isVideoRecordingEnabled) {
+        this.call.once('recording-started', () => {
+          const totalRecordingDelay = (new Date().getTime() - recordingRequestedTime) / 1000;
+          this.emit('call-start-progress', {
+            stage: 'video-recording-started',
+            status: 'completed',
+            timestamp: new Date().toISOString(),
+            metadata: { delaySeconds: totalRecordingDelay }
+          });
+
+          this.send({
+            type: 'control',
+            control: 'say-first-message',
+            videoRecordingStartDelaySeconds: totalRecordingDelay,
+          });
+        });
+      }
+
       // Stage 3: Mobile device handling and permissions
       const isMobile = this.isMobileDevice();
       this.emit('call-start-progress', {
@@ -688,11 +728,15 @@ export default class Vapi extends VapiEventEmitter {
       });
       
       const joinStartTime = Date.now();
-      
+      recordingRequestedTime = joinStartTime;
+
       try {
         await this.call.join({
           // @ts-expect-error This exists
           url: webCall.webCallUrl,
+          // daily-js rejects a `token` key that is present but undefined, so
+          // only include it when the server actually sent one.
+          ...(callToken ? { token: callToken } : {}),
           subscribeToTracksAutomatically: false,
         });
         
@@ -724,17 +768,26 @@ export default class Vapi extends VapiEventEmitter {
       }
 
       // Stage 5: Video recording setup (if enabled)
-      if (isVideoRecordingEnabled) {
+      if (isVideoRecordingEnabled && callToken) {
+        // The meeting token auto-started the recording at join, so there is
+        // nothing to request from the client.
+        this.emit('call-start-progress', {
+          stage: 'video-recording-setup',
+          status: 'completed',
+          timestamp: new Date().toISOString(),
+          metadata: { action: 'auto-started-via-meeting-token' }
+        });
+      } else if (isVideoRecordingEnabled) {
         this.emit('call-start-progress', {
           stage: 'video-recording-setup',
           status: 'started',
           timestamp: new Date().toISOString()
         });
-        
-        const recordingRequestedTime = new Date().getTime();
+
         const recordingStartTime = Date.now();
 
         try {
+          recordingRequestedTime = new Date().getTime();
           this.startRecording();
 
           const recordingSetupDuration = Date.now() - recordingStartTime;
@@ -743,22 +796,6 @@ export default class Vapi extends VapiEventEmitter {
             status: 'completed',
             duration: recordingSetupDuration,
             timestamp: new Date().toISOString()
-          });
-
-          this.call.once('recording-started', () => {
-            const totalRecordingDelay = (new Date().getTime() - recordingRequestedTime) / 1000;
-            this.emit('call-start-progress', {
-              stage: 'video-recording-started',
-              status: 'completed',
-              timestamp: new Date().toISOString(),
-              metadata: { delaySeconds: totalRecordingDelay }
-            });
-            
-            this.send({
-              type: 'control',
-              control: 'say-first-message',
-              videoRecordingStartDelaySeconds: totalRecordingDelay,
-            });
           });
         } catch (error) {
           const recordingSetupDuration = Date.now() - recordingStartTime;
@@ -1423,6 +1460,11 @@ export default class Vapi extends VapiEventEmitter {
       const isVideoRecordingEnabled = webCall?.artifactPlan?.videoRecordingEnabled ?? false;
       const isVideoEnabled = webCall?.assistant?.voice?.provider === 'tavus';
 
+      // Same auto-start token as in start(). Rejoining with it while the
+      // recording is still running is safe; if the recording stopped when the
+      // user left, the token starts a new one.
+      const callToken = webCall?.transport?.callToken;
+
       // Stage 1: Create Daily call object
       this.emit('call-start-progress', {
         stage: 'daily-call-object-creation',
@@ -1465,6 +1507,8 @@ export default class Vapi extends VapiEventEmitter {
           this.hasEmittedCallEndedStatus = true;
         }
         if (isVideoRecordingEnabled) {
+          // When using a token, the recording doesn't stop automatically on
+          // leave, so still stop it manually to preserve existing behavior.
           this.call?.stopRecording();
         }
         this.cleanup().catch(console.error);
@@ -1576,6 +1620,28 @@ export default class Vapi extends VapiEventEmitter {
         }
       });
 
+      // Registered before join(): a token-auto-started recording can begin
+      // while join() is still in flight, so a listener added after join
+      // could miss the event.
+      let recordingRequestedTime = 0;
+      if (isVideoRecordingEnabled) {
+        this.call.once('recording-started', () => {
+          const totalRecordingDelay = (new Date().getTime() - recordingRequestedTime) / 1000;
+          this.emit('call-start-progress', {
+            stage: 'video-recording-started',
+            status: 'completed',
+            timestamp: new Date().toISOString(),
+            metadata: { delaySeconds: totalRecordingDelay }
+          });
+
+          this.send({
+            type: 'control',
+            control: 'say-first-message',
+            videoRecordingStartDelaySeconds: totalRecordingDelay,
+          });
+        });
+      }
+
       // Stage 2: Mobile device handling and permissions
       const isMobile = this.isMobileDevice();
       this.emit('call-start-progress', {
@@ -1613,8 +1679,12 @@ export default class Vapi extends VapiEventEmitter {
       });
       
       const joinStartTime = Date.now();
+      recordingRequestedTime = joinStartTime;
       await this.call.join({
         url: webCall.webCallUrl,
+        // daily-js rejects a `token` key that is present but undefined, so
+        // only include it when the server actually sent one.
+        ...(callToken ? { token: callToken } : {}),
         subscribeToTracksAutomatically: false,
       });
       
@@ -1627,17 +1697,26 @@ export default class Vapi extends VapiEventEmitter {
       });
 
       // Stage 4: Video recording setup (if enabled)
-      if (isVideoRecordingEnabled) {
+      if (isVideoRecordingEnabled && callToken) {
+        // The meeting token auto-started the recording at join, so there is
+        // nothing to request from the client.
+        this.emit('call-start-progress', {
+          stage: 'video-recording-setup',
+          status: 'completed',
+          timestamp: new Date().toISOString(),
+          metadata: { action: 'auto-started-via-meeting-token' }
+        });
+      } else if (isVideoRecordingEnabled) {
         this.emit('call-start-progress', {
           stage: 'video-recording-setup',
           status: 'started',
           timestamp: new Date().toISOString()
         });
-        
+
         const recordingStartTime = Date.now();
-        const recordingRequestedTime = new Date().getTime();
 
         try {
+          recordingRequestedTime = new Date().getTime();
           this.startRecording();
 
           const recordingSetupDuration = Date.now() - recordingStartTime;
@@ -1646,22 +1725,6 @@ export default class Vapi extends VapiEventEmitter {
             status: 'completed',
             duration: recordingSetupDuration,
             timestamp: new Date().toISOString()
-          });
-
-          this.call.once('recording-started', () => {
-            const totalRecordingDelay = (new Date().getTime() - recordingRequestedTime) / 1000;
-            this.emit('call-start-progress', {
-              stage: 'video-recording-started',
-              status: 'completed',
-              timestamp: new Date().toISOString(),
-              metadata: { delaySeconds: totalRecordingDelay }
-            });
-            
-            this.send({
-              type: 'control',
-              control: 'say-first-message',
-              videoRecordingStartDelaySeconds: totalRecordingDelay,
-            });
           });
         } catch (error) {
           const recordingSetupDuration = Date.now() - recordingStartTime;


### PR DESCRIPTION
# Use meeting token to start video recording automatically

Linear: VAPICS-1216

## Context

Customers with weak network connections sometimes end calls with no `videoRecordingUrl` because the client-initiated `startRecording()` request never reaches Daily. Per Daily support's recommendation, the backend now creates a meeting token with `start_cloud_recording: true` when video recording is enabled and returns it on the web call as `call.transport.callToken`. Joining with that token makes Daily start the cloud recording automatically, which is more reliable.

This relates to #168, which allows the client to retry the recording if it fails. Both changes are needed, because the recording can still fail even when started via a token.

## Changes

**SDK (`vapi.ts`)**
- `start()` reads `call.transport.callToken` from the create-web-call response and joins the Daily room with it. When a token is present, the client-side `startRecording()` call is skipped because it will start automatically.
- `reconnect()` does the same; the `WebCall` param type gains an optional `transport.callToken` field, which is picked up automatically by apps that pass back the `Call` object from `start()`.
- The `recording-started` listener that sends the `say-first-message` control is now registered *before* `join()` in both methods. On the token path the recording can start while join is still in flight, and a listener registered after join could miss the event (and never trigger the assistant's greeting).
- The `video-recording-setup` progress event reports `metadata.action: 'auto-started-via-meeting-token'` on the token path so the two flows are distinguishable in telemetry.

**Example app** — Updated so that we can test the video recording and reconnect workflows. Video recording is now toggleable via a checkbox, a local camera preview (with recording indicator) shows when the camera is live, the stored call data includes `transport` so reconnects use the token, and Stop (leave) / End are now separate buttons (previously the stop button would always end the call, so it wasn't possible to reconnect).

## Backward compatibility

- **No token (old servers, ZDR orgs, token-creation failure):** `join()` gets no `token` key and the SDK falls back to client-initiated `startRecording()` — identical to the old flow.
- **Old SDKs + new server:** ignore the token field and keep client-initiated recording; the backend still sets room-level `enable_recording` for exactly this case.
- **Recording stop semantics are unchanged.** The recording is still stopped manually when the client leaves because the meeting token only *starts* it automatically.
- **Progress-event ordering:** on the token path, the `video-recording-started` progress event can occasionally be emitted before `video-recording-setup: completed`, because the recording may start while `join()` is still in flight (on the old client-initiated path, setup always preceded started). Consumers should not assume the ordering; each event carries a timestamp and, on the token path, a `metadata.action` discriminator for disambiguation.

## Testing

Used the example app to manually verify that video recording works, including when the caller stops and reconnects to the call. Tested against both the Vapi prod server (before the backend change), and my local test server (including the backend change), to verify that we still fall back to the old behavior when a `callToken` isn't provided.

