### PR TITLE
fix: start local audio level observer after Krisp track swap (VAP-17046)

### DIFF
--- a/__tests__/vapi.test.ts
+++ b/__tests__/vapi.test.ts
@@ -420,3 +420,138 @@ describe("Vapi audio processing failures", () => {
     expect(emitted?.error?.message).toBe("Canceled");
   });
 });
+
+// Daily tears the local audio level observer down on any local track change, and
+// its teardown closes the AudioContext that the observer's in-flight
+// audioWorklet.addModule() is still loading into. Chrome and Firefox reject that
+// load ("AbortError: Unable to load a worklet's module") and Daily responds by
+// stopping the observer for the whole call. Enabling noise cancellation swaps the
+// microphone track, so starting the observer before that swap loses the race.
+// Upstream: https://github.com/daily-co/daily-js/issues/317
+describe("Vapi local audio level observer", () => {
+  const webCall = {
+    id: "call_test",
+    webCallUrl: "https://example.daily.co/test",
+  };
+
+  // A pending updateInputSettings() stands in for Krisp still initializing, so a
+  // test can assert what the SDK does on each side of the track swap.
+  function deferredInputSettings() {
+    let settle = () => {};
+    const pending = new Promise<void>((resolve) => {
+      settle = () => resolve();
+    });
+    return { updateInputSettings: jest.fn(() => pending), settle };
+  }
+
+  afterEach(() => {
+    mockDailyCall = null;
+  });
+
+  it("does not start the observer when nothing listens for local-volume-level", async () => {
+    mockDailyCall = createMockDailyCall(jest.fn().mockResolvedValue(undefined));
+    const vapi = new Vapi("dummy_token");
+
+    await vapi.start("dummy_assistant_id");
+    await flushRejections();
+
+    expect(mockDailyCall.startLocalAudioLevelObserver).not.toHaveBeenCalled();
+    // The assistant's level is a separate observer and stays unconditional.
+    expect(
+      mockDailyCall.startRemoteParticipantsAudioLevelObserver
+    ).toHaveBeenCalledWith(100);
+  });
+
+  it("starts the observer when a local-volume-level listener is registered", async () => {
+    mockDailyCall = createMockDailyCall(jest.fn().mockResolvedValue(undefined));
+    const vapi = new Vapi("dummy_token");
+    vapi.on("local-volume-level", () => {});
+
+    await vapi.start("dummy_assistant_id");
+    await flushRejections();
+
+    expect(mockDailyCall.startLocalAudioLevelObserver).toHaveBeenCalledWith(100);
+  });
+
+  it("waits for the noise cancellation processor to settle before starting", async () => {
+    const { updateInputSettings, settle } = deferredInputSettings();
+    mockDailyCall = createMockDailyCall(updateInputSettings as jest.Mock);
+    const vapi = new Vapi("dummy_token");
+    vapi.on("local-volume-level", () => {});
+
+    await vapi.start("dummy_assistant_id");
+    await flushRejections();
+
+    // Krisp is still initializing: starting now is what loses the race.
+    expect(mockDailyCall.startLocalAudioLevelObserver).not.toHaveBeenCalled();
+
+    settle();
+    await flushRejections();
+
+    expect(mockDailyCall.startLocalAudioLevelObserver).toHaveBeenCalledWith(100);
+  });
+
+  it("starts the observer even when noise cancellation fails", async () => {
+    const updateInputSettings = jest.fn(() => {
+      return Promise.reject(new Error("Canceled"));
+    });
+    mockDailyCall = createMockDailyCall(updateInputSettings as jest.Mock);
+    const vapi = new Vapi("dummy_token");
+    vapi.on("local-volume-level", () => {});
+    // EventEmitter rethrows out of emit('error') with no listener registered,
+    // which is reported separately from the observer start for that reason.
+    vapi.on("error", () => {});
+
+    await vapi.start("dummy_assistant_id");
+    await flushRejections();
+
+    expect(mockDailyCall.startLocalAudioLevelObserver).toHaveBeenCalledWith(100);
+  });
+
+  it("reports a rejected observer start rather than letting it escape", async () => {
+    mockDailyCall = createMockDailyCall(jest.fn().mockResolvedValue(undefined));
+    mockDailyCall.startLocalAudioLevelObserver.mockRejectedValue(
+      new Error("Unable to load a worklet's module.")
+    );
+    const vapi = new Vapi("dummy_token");
+    vapi.on("local-volume-level", () => {});
+    const observerErrors: any[] = [];
+    vapi.on("local-audio-level-observer-error", (error) => {
+      observerErrors.push(error);
+    });
+
+    const call = await vapi.start("dummy_assistant_id");
+    await flushRejections();
+
+    // Non-fatal: the call still starts.
+    expect(call).not.toBeNull();
+    expect(observerErrors[0]?.message).toBe("Unable to load a worklet's module.");
+  });
+
+  it("does not start the observer on reconnect() when nothing listens", async () => {
+    mockDailyCall = createMockDailyCall(jest.fn().mockResolvedValue(undefined));
+    const vapi = new Vapi("dummy_token");
+
+    await vapi.reconnect(webCall);
+    await flushRejections();
+
+    expect(mockDailyCall.startLocalAudioLevelObserver).not.toHaveBeenCalled();
+  });
+
+  it("waits for the processor to settle on reconnect() too", async () => {
+    const { updateInputSettings, settle } = deferredInputSettings();
+    mockDailyCall = createMockDailyCall(updateInputSettings as jest.Mock);
+    const vapi = new Vapi("dummy_token");
+    vapi.on("local-volume-level", () => {});
+
+    await vapi.reconnect(webCall);
+    await flushRejections();
+
+    expect(mockDailyCall.startLocalAudioLevelObserver).not.toHaveBeenCalled();
+
+    settle();
+    await flushRejections();
+
+    expect(mockDailyCall.startLocalAudioLevelObserver).toHaveBeenCalledWith(100);
+  });
+});

--- a/vapi.ts
+++ b/vapi.ts
@@ -423,6 +423,36 @@ export default class Vapi extends VapiEventEmitter {
     });
   }
 
+  /**
+   * Starts Daily's local (microphone) audio level observer.
+   *
+   * Only runs when something is listening for 'local-volume-level'. The observer
+   * costs an AudioContext plus an AudioWorklet for the lifetime of the call and
+   * nothing else in the SDK reads the level, so starting it unconditionally
+   * charges every consumer for a feature almost none of them use. Listeners
+   * attached after the call is under way should call the public
+   * `startLocalAudioLevelObserver()`.
+   *
+   * Must run after the noise-cancellation processor has settled. Krisp replaces
+   * the microphone track, Daily reacts to any local track change by closing the
+   * AudioContext its in-flight `audioWorklet.addModule()` is still loading into,
+   * and Chrome and Firefox reject that load with "AbortError: Unable to load a
+   * worklet's module". Daily answers by stopping the observer for the rest of
+   * the call, so losing this race costs the feature, not just console noise.
+   * Tracked upstream at https://github.com/daily-co/daily-js/issues/317.
+   */
+  private async maybeStartLocalAudioLevelObserver(): Promise<void> {
+    if (!this.call || this.listenerCount('local-volume-level') === 0) {
+      return;
+    }
+
+    try {
+      await this.call.startLocalAudioLevelObserver(100);
+    } catch (error) {
+      this.emit('local-audio-level-observer-error', serializeError(error));
+    }
+  }
+
   async start(
     assistant?: CreateAssistantDTO | string,
     assistantOverrides?: AssistantOverrides,
@@ -835,7 +865,6 @@ export default class Vapi extends VapiEventEmitter {
       
       try {
         this.call.startRemoteParticipantsAudioLevelObserver(100);
-        this.call.startLocalAudioLevelObserver(100);
         const audioObserverDuration = Date.now() - audioObserverStartTime;
         this.emit('call-start-progress', {
           stage: 'audio-observer-setup',
@@ -905,17 +934,28 @@ export default class Vapi extends VapiEventEmitter {
       const audioProcessingStartTime = Date.now();
       
       try {
-        this.call
-          .updateInputSettings({
-            audio: {
-              processor: {
-                type: 'noise-cancellation',
-              },
+        const audioProcessingUpdate = this.call.updateInputSettings({
+          audio: {
+            processor: {
+              type: 'noise-cancellation',
             },
-          })
-          .catch((error) => {
-            this.emitAudioProcessingError('audio-processing-setup', error);
-          });
+          },
+        });
+
+        audioProcessingUpdate.catch((error) => {
+          this.emitAudioProcessingError('audio-processing-setup', error);
+        });
+
+        // The observer waits for this update rather than starting alongside the
+        // remote one above, so that Krisp has already swapped the microphone
+        // track. See maybeStartLocalAudioLevelObserver().
+        //
+        // A separate chain, not another link on the one above: EventEmitter
+        // rethrows out of emit('error') when a consumer registered no 'error'
+        // listener, and whether the observer starts must not hinge on that.
+        audioProcessingUpdate
+          .catch(() => {})
+          .then(() => this.maybeStartLocalAudioLevelObserver());
 
         const audioProcessingDuration = Date.now() - audioProcessingStartTime;
         this.emit('call-start-progress', {
@@ -1758,7 +1798,6 @@ export default class Vapi extends VapiEventEmitter {
       
       try {
         this.call.startRemoteParticipantsAudioLevelObserver(100);
-        this.call.startLocalAudioLevelObserver(100);
         const audioObserverDuration = Date.now() - audioObserverStartTime;
         this.emit('call-start-progress', {
           stage: 'audio-observer-setup',
@@ -1789,17 +1828,28 @@ export default class Vapi extends VapiEventEmitter {
       const audioProcessingStartTime = Date.now();
       
       try {
-        this.call
-          .updateInputSettings({
-            audio: {
-              processor: {
-                type: 'noise-cancellation',
-              },
+        const audioProcessingUpdate = this.call.updateInputSettings({
+          audio: {
+            processor: {
+              type: 'noise-cancellation',
             },
-          })
-          .catch((error) => {
-            this.emitAudioProcessingError('audio-processing-setup', error);
-          });
+          },
+        });
+
+        audioProcessingUpdate.catch((error) => {
+          this.emitAudioProcessingError('audio-processing-setup', error);
+        });
+
+        // The observer waits for this update rather than starting alongside the
+        // remote one above, so that Krisp has already swapped the microphone
+        // track. See maybeStartLocalAudioLevelObserver().
+        //
+        // A separate chain, not another link on the one above: EventEmitter
+        // rethrows out of emit('error') when a consumer registered no 'error'
+        // listener, and whether the observer starts must not hinge on that.
+        audioProcessingUpdate
+          .catch(() => {})
+          .then(() => this.maybeStartLocalAudioLevelObserver());
 
         const audioProcessingDuration = Date.now() - audioProcessingStartTime;
         this.emit('call-start-progress', {


### PR DESCRIPTION
Fixes VAP-17046

## Problem

`vapi.start()` called `startLocalAudioLevelObserver()` unconditionally, and *before* noise cancellation was applied. Krisp then swaps the microphone track, which makes daily-js run `stopProcessing()` → `startProcessing()` — closing the `AudioContext` while the observer's AudioWorklet module is still loading. The load aborts and the observer is dead for the rest of the call.

Reported by a customer on `@vapi-ai/web` 2.6.1. Two console errors on every call, in Chrome and Firefox but not Safari:

```
Failed to add Module: AbortError: Unable to load a worklet's module.
Error when starting local audio level observer!
```

Introduced in d4d52d7 (#162). Benign for call audio, transcription and the microphone itself, but it permanently breaks the `local-volume-level` feature — and it fired for every integration whether or not they consume that event.

## Fix

1. Start the observer only when a `local-volume-level` listener is registered.
2. Chain it after `updateInputSettings()` settles, so Krisp has already swapped the track before the worklet loads.

The observer start hangs off a separate chain from the error-reporting `.catch()`, because `EventEmitter` rethrows out of `emit('error')` when the consumer registered no `'error'` listener — whether the observer starts must not hinge on that.

## Verification

12 real web calls in Chrome with `AudioWorklet.addModule()` and `AudioContext.close()` instrumented in-page: 3 rounds × 2 scenarios × 2 builds.

Unpatched, every call closed the context 1ms before the observer's worklet load:

```
addModule=[1235ms +3ms ok, 1424ms +3ms ok, 3027ms +4ms ok]  closes=[3026]
```

A 3ms window with a 1ms margin. One run showed a load taking 89ms rather than 3ms, which is the variance that makes this fire on customer machines and not on ours.

Patched, every call:

```
addModule=[1446ms +4ms ok]  closes=[]
```

Zero context closes. The fix removes the event that opens the race rather than narrowing it.

Both scenarios were checked, because gating alone could have "fixed" the console by disabling the feature:

| | unpatched | patched |
|---|---|---|
| `AudioContext` closes | 1 per call | 0 |
| worklet loads, no listener | 3 | 1 |
| worklet loads, with listener | 3 | 2 |
| `local-volume-level` events | 298 | 260–264 |

Krisp genuinely engaged throughout (`inputSettings` ends at `{"audio":{"processor":{"type":"noise-cancellation"}}}`), so this was a realistic environment rather than one where noise cancellation silently no-opped.

Unit coverage added for the gate, the ordering, and failure reporting, on both `start()` and `reconnect()`. Full suite: 61 passing, `tsc --noEmit` clean.

## Upstream

Filed as [daily-co/daily-js#317](https://github.com/daily-co/daily-js/issues/317). Two defects there:

1. `stopProcessing()` closes the `AudioContext` without cancelling or awaiting an in-flight `addModule()`.
2. `this.blobURL` is instance state shared across attempts, so a losing attempt's cleanup can revoke the blob URL of a successful retry.

Reproduced on daily-js 0.87.0, 0.91.0 and 0.92.2. This fix avoids the race and does not depend on the upstream one landing.
